### PR TITLE
feat: support optional/required fields via the zod schema

### DIFF
--- a/web/src/components/AutoField/field.utils.test.tsx
+++ b/web/src/components/AutoField/field.utils.test.tsx
@@ -77,7 +77,7 @@ describe('getInputComponentFromZodType', () => {
   })
 
   describe('when given ZodNumber', () => {
-    function expectComponentToBeNumberField(
+    function expectNumberField(
       Comp: ReturnType<typeof getInputComponentFromZod>
     ) {
       renderInForm(<Comp name={NAME} />)
@@ -92,35 +92,44 @@ describe('getInputComponentFromZodType', () => {
     describe('that is required', () => {
       it('should return NumberField', () => {
         const Component = getInputComponentFromZod(z.number())
-        expectComponentToBeNumberField(Component)
+        expectNumberField(Component)
       })
     })
 
     describe('that is optional', () => {
       it('should return NumberField', () => {
         const Component = getInputComponentFromZod(z.number().optional())
-        expectComponentToBeNumberField(Component)
+        expectNumberField(Component)
       })
     })
 
     describe('that accepts NaN', () => {
       it('should return NumberField', () => {
         const Component = getInputComponentFromZod(z.number().or(z.nan()))
-        expectComponentToBeNumberField(Component)
+        expectNumberField(Component)
       })
     })
   })
 
   describe('when given ZodDate', () => {
-    const schema = z.date()
-
-    it('should return DateField', () => {
-      const Component = getInputComponentFromZod(schema)
-      renderInForm(<Component name={NAME} />)
+    function expectDateField(
+      Comp: ReturnType<typeof getInputComponentFromZod>
+    ) {
+      renderInForm(<Comp name={NAME} />)
       const element = screen.getByLabelText<HTMLInputElement>(titleCase(NAME))
       expect(element).toBeInTheDocument()
       expect(element.type).toEqual('date')
       expect(element.name).toEqual(NAME)
+    }
+
+    it('should return DateField', () => {
+      const Component = getInputComponentFromZod(z.date())
+      expectDateField(Component)
+    })
+
+    it('should return DateField when nullable', () => {
+      const Component = getInputComponentFromZod(z.date().nullable())
+      expectDateField(Component)
     })
   })
 

--- a/web/src/components/AutoField/field.utils.test.tsx
+++ b/web/src/components/AutoField/field.utils.test.tsx
@@ -58,17 +58,10 @@ describe('getInputComponentFromZodType', () => {
 
   describe('when given ZodArray', () => {
     const options = ['bar', 'baz', 'qux'] as const
-    const schema = z.enum(options).array()
-
-    it('should throw error on arbitrary arrays', () => {
-      expect(() => getInputComponentFromZod(z.string().array())).toThrow(
-        'ZodArray not yet supported'
-      )
-    })
-
-    it('should return CheckboxField when it is an array of an enum', () => {
-      const Component = getInputComponentFromZod(schema)
-      renderInForm(<Component name={NAME} />)
+    function expectCheckboxField(
+      Comp: ReturnType<typeof getInputComponentFromZod>
+    ) {
+      renderInForm(<Comp name={NAME} />)
       const optionElements = screen.getAllByRole<HTMLInputElement>('checkbox')
       expect(optionElements.length).toEqual(options.length)
       options.forEach((option, index) => {
@@ -82,6 +75,24 @@ describe('getInputComponentFromZodType', () => {
         )
         expect(element).toBe(labeledElement)
       })
+    }
+
+    it('should throw error on arbitrary arrays', () => {
+      expect(() => getInputComponentFromZod(z.string().array())).toThrow(
+        'ZodArray not yet supported'
+      )
+    })
+
+    it('should return CheckboxField when it is an array of enums', () => {
+      const Component = getInputComponentFromZod(z.enum(options).array())
+      expectCheckboxField(Component)
+    })
+
+    it('should return CheckboxField when it is an array of enums or a `false`', () => {
+      const Component = getInputComponentFromZod(
+        z.enum(options).array().or(z.literal(false))
+      )
+      expectCheckboxField(Component)
     })
   })
 

--- a/web/src/components/AutoField/field.utils.test.tsx
+++ b/web/src/components/AutoField/field.utils.test.tsx
@@ -26,11 +26,10 @@ const LABEL_TEXT = titleCase(NAME)
 describe('getInputComponentFromZodType', () => {
   describe('when given ZodEnum', () => {
     const options = ['bar', 'baz', 'qux'] as const
-    const schema = z.enum(options)
-
-    it('should return RadioField', () => {
-      const Component = getInputComponentFromZod(schema)
-      renderInForm(<Component name={NAME} />)
+    function expectRadioField(
+      Comp: ReturnType<typeof getInputComponentFromZod>
+    ) {
+      renderInForm(<Comp name={NAME} />)
       const optionElements = screen.getAllByRole<HTMLInputElement>('radio')
       expect(optionElements.length).toEqual(options.length)
       options.forEach((option, index) => {
@@ -44,6 +43,16 @@ describe('getInputComponentFromZodType', () => {
         )
         expect(element).toBe(labeledElement)
       })
+    }
+
+    it('should return RadioField', () => {
+      const Component = getInputComponentFromZod(z.enum(options))
+      expectRadioField(Component)
+    })
+
+    it('should return RadioField when nullable', () => {
+      const Component = getInputComponentFromZod(z.enum(options).nullable())
+      expectRadioField(Component)
     })
   })
 

--- a/web/src/components/AutoField/field.utils.test.tsx
+++ b/web/src/components/AutoField/field.utils.test.tsx
@@ -138,17 +138,6 @@ describe('getInputComponentFromZodType', () => {
       expect(element).toBe(labeledElement)
     })
 
-    it('should return TextField when there are no checks', () => {
-      const Component = getInputComponentFromZod(schema)
-      renderInForm(<Component name={NAME} />)
-      const element = screen.getByRole<HTMLInputElement>('textbox')
-      expect(element).toBeInTheDocument()
-      expect(element.type).toEqual('text')
-      expect(element.name).toEqual(NAME)
-      const labeledElement = screen.getByLabelText<HTMLInputElement>(LABEL_TEXT)
-      expect(element).toBe(labeledElement)
-    })
-
     it('should return TextField when there are only non-email checks', () => {
       const Component = getInputComponentFromZod(schema.ip())
       renderInForm(<Component name={NAME} />)

--- a/web/src/components/AutoField/field.utils.test.tsx
+++ b/web/src/components/AutoField/field.utils.test.tsx
@@ -77,17 +77,37 @@ describe('getInputComponentFromZodType', () => {
   })
 
   describe('when given ZodNumber', () => {
-    const schema = z.number()
-
-    it('should return NumberField', () => {
-      const Component = getInputComponentFromZod(schema)
-      renderInForm(<Component name={NAME} />)
+    function expectComponentToBeNumberField(
+      Comp: ReturnType<typeof getInputComponentFromZod>
+    ) {
+      renderInForm(<Comp name={NAME} />)
       const element = screen.getByRole<HTMLInputElement>('spinbutton')
       expect(element).toBeInTheDocument()
       expect(element.type).toEqual('number')
       expect(element.name).toEqual(NAME)
       const labeledElement = screen.getByLabelText<HTMLInputElement>(LABEL_TEXT)
       expect(element).toBe(labeledElement)
+    }
+
+    describe('that is required', () => {
+      it('should return NumberField', () => {
+        const Component = getInputComponentFromZod(z.number())
+        expectComponentToBeNumberField(Component)
+      })
+    })
+
+    describe('that is optional', () => {
+      it('should return NumberField', () => {
+        const Component = getInputComponentFromZod(z.number().optional())
+        expectComponentToBeNumberField(Component)
+      })
+    })
+
+    describe('that accepts NaN', () => {
+      it('should return NumberField', () => {
+        const Component = getInputComponentFromZod(z.number().or(z.nan()))
+        expectComponentToBeNumberField(Component)
+      })
     })
   })
 
@@ -106,6 +126,17 @@ describe('getInputComponentFromZodType', () => {
 
   describe('when given ZodString', () => {
     const schema = z.string()
+
+    it('should return TextField when there are no checks', () => {
+      const Component = getInputComponentFromZod(schema)
+      renderInForm(<Component name={NAME} />)
+      const element = screen.getByRole<HTMLInputElement>('textbox')
+      expect(element).toBeInTheDocument()
+      expect(element.type).toEqual('text')
+      expect(element.name).toEqual(NAME)
+      const labeledElement = screen.getByLabelText<HTMLInputElement>(LABEL_TEXT)
+      expect(element).toBe(labeledElement)
+    })
 
     it('should return TextField when there are no checks', () => {
       const Component = getInputComponentFromZod(schema)

--- a/web/src/components/AutoField/field.utils.tsx
+++ b/web/src/components/AutoField/field.utils.tsx
@@ -62,16 +62,27 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
         />
       </Label>
     )
-  } else if (zodUtils.isEnumDef(type._def)) {
+  } else if (
+    zodUtils.isEnumDef(type._def) ||
+    zodUtils.isNullableEnumDef(type._def)
+  ) {
+    const [values, required] = zodUtils.isEnumDef(type._def)
+      ? [type._def.values, true]
+      : [type._def.innerType._def.values, false]
     return ({
       name,
       ...props
     }: Omit<ComponentProps<typeof RadioField>, 'ref' | 'value'> &
       RefAttributes<HTMLInputElement>) => (
       <>
-        {type._def.values.map((value, index) => (
+        {values.map((value, index) => (
           <Label name={value} key={index}>
-            <RadioField name={name} value={value} {...props} />
+            <RadioField
+              name={name}
+              value={value}
+              validation={{ required }}
+              {...props}
+            />
           </Label>
         ))}
       </>

--- a/web/src/components/AutoField/field.utils.tsx
+++ b/web/src/components/AutoField/field.utils.tsx
@@ -5,18 +5,7 @@ import {
   type RefAttributes,
 } from 'react'
 
-import type {
-  ZodArrayDef,
-  ZodDateDef,
-  ZodEnumDef,
-  ZodNumberDef,
-  ZodOptionalDef,
-  ZodStringDef,
-  ZodTypeAny,
-  ZodTypeDef,
-  ZodUnionDef,
-} from 'zod'
-import { ZodFirstPartyTypeKind, ZodNaN, ZodNumber, ZodOptional } from 'zod'
+import type { ZodTypeAny, ZodTypeDef } from 'zod'
 
 import {
   CheckboxField,
@@ -32,44 +21,41 @@ import {
 } from '@redwoodjs/forms'
 
 import { DefaultLabel } from 'src/components/AutoField/labeled-inputs'
+import * as zodUtils from 'src/components/AutoField/zod.utils'
 
 export function getInputComponentFromZod<T extends ZodTypeAny>(
   type: T,
   Label = DefaultLabel
 ) {
-  if (isStringDef(type._def)) {
-    const emailCheck = type._def.checks.find(({ kind }) => kind === 'email')
-    const urlCheck = type._def.checks.find(({ kind }) => kind === 'url')
-    const StringComponent = emailCheck
-      ? EmailField
-      : urlCheck
-      ? UrlField
-      : TextField
+  if (zodUtils.isStringDef(type._def)) {
+    const isEmail = zodUtils.containsCheck(type._def, 'email')
+    const isUrl = zodUtils.containsCheck(type._def, 'url')
+    const StringComponent = isEmail ? EmailField : isUrl ? UrlField : TextField
     return ({ name, ...props }: ComponentProps<typeof TextField>) => (
       <Label name={name}>
         <StringComponent name={name} {...props} />
       </Label>
     )
-  } else if (isDateDef(type._def)) {
+  } else if (zodUtils.isDateDef(type._def)) {
     return ({ name, ...props }: ComponentProps<typeof DateField>) => (
       <Label name={name}>
         <DateField name={name} {...props} />
       </Label>
     )
-  } else if (isNumberDef(type._def) || isNumberOptional(type._def)) {
+  } else if (isRequiredNumber(type._def) || isOptionalNumber(type._def)) {
     return ({ name, ...props }: ComponentProps<typeof NumberField>) => (
       <Label name={name}>
         <NumberField
           name={name}
           validation={{
             valueAsNumber: true,
-            required: !isNumberOptional(type._def),
+            required: !isOptionalNumber(type._def),
           }}
           {...props}
         />
       </Label>
     )
-  } else if (isEnumDef(type._def)) {
+  } else if (zodUtils.isEnumDef(type._def)) {
     return ({
       name,
       ...props
@@ -83,7 +69,10 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
         ))}
       </>
     )
-  } else if (isArrayDef(type._def) && isEnumDef(type._def.type._def)) {
+  } else if (
+    zodUtils.isArrayDef(type._def) &&
+    zodUtils.isEnumDef(type._def.type._def)
+  ) {
     const { values } = type._def.type._def
     return ({
       name,
@@ -100,63 +89,21 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
     )
   }
 
-  throw new Error(`zod schema of ${getDefType(type._def)} not yet supported`)
-}
-
-function isNumberOptional(def: ZodTypeDef) {
-  return isOptionalNumberDef(def) || isNaNUnionDef(def)
-}
-
-function isOptionalNumberDef(
-  def: ZodTypeDef
-): def is ZodOptionalDef<ZodNumber> {
-  return isOptionalDef(def) && def.innerType instanceof ZodNumber
-}
-
-function isNaNUnionDef(
-  def: ZodTypeDef
-): def is ZodUnionDef<[ZodNumber, ZodNaN]> {
-  return (
-    isUnionDef(def) &&
-    (def.options[0] instanceof ZodNumber ||
-      def.options[0] instanceof ZodOptional) &&
-    def.options[1] instanceof ZodNaN
+  throw new Error(
+    `zod schema of ${zodUtils.getDefType(type._def)} not yet supported`
   )
 }
 
-function isOptionalDef(def: ZodTypeDef): def is ZodOptionalDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodOptional
+function isRequiredNumber(def: ZodTypeDef) {
+  return zodUtils.isNumberDef(def)
 }
 
-function isUnionDef(def: ZodTypeDef): def is ZodUnionDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodUnion
-}
-
-function isDateDef(def: ZodTypeDef): def is ZodDateDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodDate
-}
-
-function isNumberDef(def: ZodTypeDef): def is ZodNumberDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodNumber
-}
-
-function isEnumDef(def: ZodTypeDef): def is ZodEnumDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodEnum
-}
-
-function isArrayDef(def: ZodTypeDef): def is ZodArrayDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodArray
-}
-
-export function getDefType(def: ZodTypeDef): ZodFirstPartyTypeKind {
-  // Every ZodTypeDef contains a typeName
-  // but the zod types don't accurately reflect that, hence the casting
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (def as any).typeName
-}
-
-function isStringDef(def: ZodTypeDef): def is ZodStringDef {
-  return getDefType(def) === ZodFirstPartyTypeKind.ZodString
+/**
+ * Optional numbers can be represented by a `.or(z.nan())` due to the way react-hook-forms and zod handle the empty string.
+ * This accounts for both cases.
+ */
+function isOptionalNumber(def: ZodTypeDef) {
+  return zodUtils.isOptionalNumberDef(def) || zodUtils.isNaNUnionDef(def)
 }
 
 export type Override = FC<InputFieldProps> | InputFieldProps['type']

--- a/web/src/components/AutoField/field.utils.tsx
+++ b/web/src/components/AutoField/field.utils.tsx
@@ -88,10 +88,12 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
       </>
     )
   } else if (
-    zodUtils.isArrayDef(type._def) &&
-    zodUtils.isEnumDef(type._def.type._def)
+    zodUtils.isArrayOfEnumsDef(type._def) ||
+    zodUtils.isArrayOfEnumsAndLiteralUnionDef(type._def)
   ) {
-    const { values } = type._def.type._def
+    const [values, required] = zodUtils.isArrayOfEnumsDef(type._def)
+      ? [type._def.type._def.values, true]
+      : [type._def.options[0]._def.type._def.values, false]
     return ({
       name,
       ...props
@@ -100,7 +102,12 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
       <>
         {values.map((value, index) => (
           <Label name={value} key={index}>
-            <CheckboxField name={name} value={value} {...props} />
+            <CheckboxField
+              name={name}
+              value={value}
+              validation={{ required }}
+              {...props}
+            />
           </Label>
         ))}
       </>

--- a/web/src/components/AutoField/field.utils.tsx
+++ b/web/src/components/AutoField/field.utils.tsx
@@ -36,10 +36,17 @@ export function getInputComponentFromZod<T extends ZodTypeAny>(
         <StringComponent name={name} {...props} />
       </Label>
     )
-  } else if (zodUtils.isDateDef(type._def)) {
+  } else if (
+    zodUtils.isDateDef(type._def) ||
+    zodUtils.isNullableDateDef(type._def)
+  ) {
     return ({ name, ...props }: ComponentProps<typeof DateField>) => (
       <Label name={name}>
-        <DateField name={name} {...props} />
+        <DateField
+          name={name}
+          validation={{ required: !zodUtils.isNullableDateDef(type._def) }}
+          {...props}
+        />
       </Label>
     )
   } else if (isRequiredNumber(type._def) || isOptionalNumber(type._def)) {

--- a/web/src/components/AutoField/zod.utils.ts
+++ b/web/src/components/AutoField/zod.utils.ts
@@ -12,6 +12,7 @@ import type {
 } from 'zod'
 import {
   ZodDate,
+  ZodEnum,
   ZodFirstPartyTypeKind,
   ZodNaN,
   ZodNumber,
@@ -87,6 +88,15 @@ export function isNullableDateDef(
   def: ZodTypeDef
 ): def is ZodNullableDef<ZodDate> {
   return isNullableDef(def) && def.innerType instanceof ZodDate
+}
+
+/**
+ * z.enum(options).nullable()
+ */
+export function isNullableEnumDef<T extends [string, ...string[]]>(
+  def: ZodTypeDef
+): def is ZodNullableDef<ZodEnum<T>> {
+  return isNullableDef(def) && def.innerType instanceof ZodEnum
 }
 
 /**

--- a/web/src/components/AutoField/zod.utils.ts
+++ b/web/src/components/AutoField/zod.utils.ts
@@ -1,0 +1,80 @@
+import type {
+  ZodArrayDef,
+  ZodDateDef,
+  ZodEnumDef,
+  ZodNumberDef,
+  ZodOptionalDef,
+  ZodStringCheck,
+  ZodStringDef,
+  ZodTypeDef,
+  ZodUnionDef,
+} from 'zod'
+import { ZodFirstPartyTypeKind, ZodNaN, ZodNumber, ZodOptional } from 'zod'
+
+export function getDefType(def: ZodTypeDef): ZodFirstPartyTypeKind {
+  // Every ZodTypeDef contains a typeName
+  // but the zod types don't accurately reflect that, hence the casting
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (def as any).typeName
+}
+
+/**
+ *  z.number().optional()
+ */
+export function isOptionalNumberDef(
+  def: ZodTypeDef
+): def is ZodOptionalDef<ZodNumber> {
+  return isOptionalDef(def) && def.innerType instanceof ZodNumber
+}
+
+/**
+ *  z.number().or(z.nan())
+ */
+export function isNaNUnionDef(
+  def: ZodTypeDef
+): def is ZodUnionDef<[ZodNumber, ZodNaN]> {
+  return (
+    isUnionDef(def) &&
+    (def.options[0] instanceof ZodNumber ||
+      def.options[0] instanceof ZodOptional) &&
+    def.options[1] instanceof ZodNaN
+  )
+}
+
+export function isOptionalDef(def: ZodTypeDef): def is ZodOptionalDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodOptional
+}
+
+export function isUnionDef(def: ZodTypeDef): def is ZodUnionDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodUnion
+}
+
+export function isDateDef(def: ZodTypeDef): def is ZodDateDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodDate
+}
+
+export function isNumberDef(def: ZodTypeDef): def is ZodNumberDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodNumber
+}
+
+export function isEnumDef(def: ZodTypeDef): def is ZodEnumDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodEnum
+}
+
+export function isArrayDef(def: ZodTypeDef): def is ZodArrayDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodArray
+}
+
+export function isStringDef(def: ZodTypeDef): def is ZodStringDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodString
+}
+
+/**
+ * TODO: rethink this logic so it doesn't loop through everything on every call
+ */
+export function containsCheck(
+  def: ZodStringDef,
+  check: ZodStringCheck['kind']
+) {
+  return def.checks.find(({ kind }) => kind === check) !== undefined
+}

--- a/web/src/components/AutoField/zod.utils.ts
+++ b/web/src/components/AutoField/zod.utils.ts
@@ -2,6 +2,7 @@ import type {
   ZodArrayDef,
   ZodDateDef,
   ZodEnumDef,
+  ZodNullableDef,
   ZodNumberDef,
   ZodOptionalDef,
   ZodStringCheck,
@@ -9,7 +10,13 @@ import type {
   ZodTypeDef,
   ZodUnionDef,
 } from 'zod'
-import { ZodFirstPartyTypeKind, ZodNaN, ZodNumber, ZodOptional } from 'zod'
+import {
+  ZodDate,
+  ZodFirstPartyTypeKind,
+  ZodNaN,
+  ZodNumber,
+  ZodOptional,
+} from 'zod'
 
 export function getDefType(def: ZodTypeDef): ZodFirstPartyTypeKind {
   // Every ZodTypeDef contains a typeName
@@ -67,6 +74,19 @@ export function isArrayDef(def: ZodTypeDef): def is ZodArrayDef {
 
 export function isStringDef(def: ZodTypeDef): def is ZodStringDef {
   return getDefType(def) === ZodFirstPartyTypeKind.ZodString
+}
+
+export function isNullableDef(def: ZodTypeDef): def is ZodNullableDef {
+  return getDefType(def) === ZodFirstPartyTypeKind.ZodNullable
+}
+
+/**
+ * z.date().nullable()
+ */
+export function isNullableDateDef(
+  def: ZodTypeDef
+): def is ZodNullableDef<ZodDate> {
+  return isNullableDef(def) && def.innerType instanceof ZodDate
 }
 
 /**

--- a/web/src/components/AutoField/zod.utils.ts
+++ b/web/src/components/AutoField/zod.utils.ts
@@ -11,9 +11,11 @@ import type {
   ZodUnionDef,
 } from 'zod'
 import {
+  ZodArray,
   ZodDate,
   ZodEnum,
   ZodFirstPartyTypeKind,
+  ZodLiteral,
   ZodNaN,
   ZodNumber,
   ZodOptional,
@@ -33,6 +35,22 @@ export function isOptionalNumberDef(
   def: ZodTypeDef
 ): def is ZodOptionalDef<ZodNumber> {
   return isOptionalDef(def) && def.innerType instanceof ZodNumber
+}
+
+/**
+ *  z.enum(options).array().or(z.literal(false))
+ */
+export function isArrayOfEnumsAndLiteralUnionDef<
+  A extends [string, ...string[]],
+  L
+>(def: ZodTypeDef): def is ZodUnionDef<[ZodArray<ZodEnum<A>>, ZodLiteral<L>]> {
+  return (
+    isUnionDef(def) &&
+    def.options[0] instanceof ZodArray &&
+    isArrayDef(def.options[0]._def) &&
+    isEnumDef(def.options[0]._def.type._def) &&
+    def.options[1] instanceof ZodLiteral
+  )
 }
 
 /**
@@ -71,6 +89,12 @@ export function isEnumDef(def: ZodTypeDef): def is ZodEnumDef {
 
 export function isArrayDef(def: ZodTypeDef): def is ZodArrayDef {
   return getDefType(def) === ZodFirstPartyTypeKind.ZodArray
+}
+
+export function isArrayOfEnumsDef<T extends [string, ...string[]]>(
+  def: ZodTypeDef
+): def is ZodArrayDef<ZodEnum<T>> {
+  return isArrayDef(def) && isEnumDef(def.type._def)
 }
 
 export function isStringDef(def: ZodTypeDef): def is ZodStringDef {

--- a/web/src/components/AutoForm/README.md
+++ b/web/src/components/AutoForm/README.md
@@ -436,19 +436,24 @@ export default function Usage() {
 
 
 ## Required vs. optional fields
-Due to the way HTML forms work (i.e. doing nothing in an `<input>` usually results in a `""` value), some zod tweaks may be needed to properly represent required and optional fields.
-Here is a quick guide.
+Due to the way HTML forms work (i.e. doing nothing in an `<input>` usually results in a `""` value), the state of "the user has not entered anything" may get represented in unintuitive ways when stitching together `zod`, `react-hook-form` (which is what `@redwoodjs/forms` is built on), and `@hookform/resolvers`.
 
-Note: this isn't directly related to this component, but is more of a guide on how html forms, `zod`, `react-hook-form` (which is what `@redwoodjs/forms` is built on), and `@hookform/resolvers` all play together.
+The below is not directly related to the `AutoForm` component but instead is a guide for how to represent optional and required fields with the above tools.
 
 ```tsx
-const schema = z.object({
   // leaving a `<input type="number">` empty results in a `NaN`.
-  // what you choode to do with the NaN is up to you.
-  required_number: z
-    .number({ invalid_type_error: "Number is required" }),
-  optional_number: z
-    .number()
-    .or(z.nan())
+  // what you choose to do with the NaN is up to you.
+const schema = z.object({
+  required_number: z.number({ invalid_type_error: 'Number is required' }),
+  optional_number: z.number().or(z.nan()),
+});
+```
+```tsx
+  // leaving a `<input type="text">` empty results in a `""`.
+  // use the length checks to eliminate empty strings.
+  // what you choose to do with the empty string is up to you.
+const schema = z.object({
+  required_string: z.string().min(1, 'String is required'),
+  optional_string: z.string(),
 });
 ```

--- a/web/src/components/AutoForm/README.md
+++ b/web/src/components/AutoForm/README.md
@@ -448,6 +448,7 @@ const schema = z.object({
   optional_number: z.number().or(z.nan()),
 });
 ```
+
 ```tsx
   // leaving a `<input type="text">` empty results in a `""`.
   // use the length checks to eliminate empty strings.
@@ -455,5 +456,14 @@ const schema = z.object({
 const schema = z.object({
   required_string: z.string().min(1, 'String is required'),
   optional_string: z.string(),
+});
+```
+
+```tsx
+  // leaving a `<input type="date">` empty results in a `null`.
+  // what you choose to do with the null is up to you.
+const schema = z.object({
+  required_date: z.date({ invalid_type_error: 'Date is required' }),
+  optional_date: z.date().nullable(),
 });
 ```

--- a/web/src/components/AutoForm/README.md
+++ b/web/src/components/AutoForm/README.md
@@ -442,7 +442,7 @@ The below is not directly related to the `AutoForm` component but instead is a g
 
 ```tsx
   // leaving a `<input type="number">` empty results in a `NaN`.
-  // what you choose to do with the NaN is up to you.
+  // what you choose to do with the `NaN` is up to you.
 const schema = z.object({
   required_number: z.number({ invalid_type_error: 'Number is required' }),
   optional_number: z.number().or(z.nan()),
@@ -461,9 +461,20 @@ const schema = z.object({
 
 ```tsx
   // leaving a `<input type="date">` empty results in a `null`.
-  // what you choose to do with the null is up to you.
+  // what you choose to do with the `null` is up to you.
 const schema = z.object({
   required_date: z.date({ invalid_type_error: 'Date is required' }),
   optional_date: z.date().nullable(),
+});
+```
+
+```tsx
+  // leaving a `<input type="radio">` empty results in a `null`.
+  // what you choose to do with the `null` is up to you.
+const schema = z.object({
+  required_radio: z.enum(options, {
+    invalid_type_error: 'Radio is required',
+  }),
+  optional_radio: z.enum(options).nullable(),
 });
 ```

--- a/web/src/components/AutoForm/README.md
+++ b/web/src/components/AutoForm/README.md
@@ -441,8 +441,8 @@ Due to the way HTML forms work (i.e. doing nothing in an `<input>` usually resul
 The below is not directly related to the `AutoForm` component but instead is a guide for how to represent optional and required fields with the above tools.
 
 ```tsx
-  // leaving a `<input type="number">` empty results in a `NaN`.
-  // what you choose to do with the `NaN` is up to you.
+// leaving a `<input type="number">` empty results in a `NaN`.
+// what you choose to do with the `NaN` is up to you.
 const schema = z.object({
   required_number: z.number({ invalid_type_error: 'Number is required' }),
   optional_number: z.number().or(z.nan()),
@@ -450,9 +450,9 @@ const schema = z.object({
 ```
 
 ```tsx
-  // leaving a `<input type="text">` empty results in a `""`.
-  // use the length checks to eliminate empty strings.
-  // what you choose to do with the empty string is up to you.
+// leaving a `<input type="text">` empty results in a `""`.
+// use the length checks to eliminate empty strings.
+// what you choose to do with the empty string is up to you.
 const schema = z.object({
   required_string: z.string().min(1, 'String is required'),
   optional_string: z.string(),
@@ -460,8 +460,8 @@ const schema = z.object({
 ```
 
 ```tsx
-  // leaving a `<input type="date">` empty results in a `null`.
-  // what you choose to do with the `null` is up to you.
+// leaving a `<input type="date">` empty results in a `null`.
+// what you choose to do with the `null` is up to you.
 const schema = z.object({
   required_date: z.date({ invalid_type_error: 'Date is required' }),
   optional_date: z.date().nullable(),
@@ -469,12 +469,27 @@ const schema = z.object({
 ```
 
 ```tsx
-  // leaving a `<input type="radio">` empty results in a `null`.
-  // what you choose to do with the `null` is up to you.
+// leaving a `<input type="radio">` empty results in a `null`.
+// what you choose to do with the `null` is up to you.
 const schema = z.object({
   required_radio: z.enum(options, {
     invalid_type_error: 'Radio is required',
   }),
   optional_radio: z.enum(options).nullable(),
+});
+```
+
+```tsx
+// never touching a `<input type="checkbox">` empty results in a `false`.
+// checking and unchecking results in an empty array.
+// what you choose to do with the `false` is up to you.
+const schema = z.object({
+  required_checkbox: z
+    .enum(options, {
+      invalid_type_error: 'Checkbox selection required',
+    })
+    .array()
+    .nonempty('Checkbox selection required'),
+  optional_checkbox: z.enum(options).array().or(z.literal(false)),
 });
 ```

--- a/web/src/components/AutoForm/README.md
+++ b/web/src/components/AutoForm/README.md
@@ -433,3 +433,22 @@ export default function Usage() {
   );
 }
 ```
+
+
+## Required vs. optional fields
+Due to the way HTML forms work (i.e. doing nothing in an `<input>` usually results in a `""` value), some zod tweaks may be needed to properly represent required and optional fields.
+Here is a quick guide.
+
+Note: this isn't directly related to this component, but is more of a guide on how html forms, `zod`, `react-hook-form` (which is what `@redwoodjs/forms` is built on), and `@hookform/resolvers` all play together.
+
+```tsx
+const schema = z.object({
+  // leaving a `<input type="number">` empty results in a `NaN`.
+  // what you choode to do with the NaN is up to you.
+  required_number: z
+    .number({ invalid_type_error: "Number is required" }),
+  optional_number: z
+    .number()
+    .or(z.nan())
+});
+```


### PR DESCRIPTION
Due to the way HTML forms work (i.e. doing nothing in an `<input>` usually results in a `""` value), the state of "the user has not entered anything" may get represented in unintuitive ways when stitching together `zod`, `react-hook-form` (which is what `@redwoodjs/forms` is built on), and `@hookform/resolvers`.

This PR documents the ways you can work around this oddity while adding support for those workarounds.

One later follow up is to detect when something is required, apply a CSS class so someone can add their  `after:content-['*'] after:ml-1 after:text-primary` for required fields.